### PR TITLE
turn on make_coupler_mosaic_gpu

### DIFF
--- a/fmsgridtools/make_mosaic/coupler_mosaic.py
+++ b/fmsgridtools/make_mosaic/coupler_mosaic.py
@@ -190,7 +190,7 @@ def get_atmxlnd(atmxocn_landpart: type[XGridObj], atm_mosaic: type[MosaicObj] = 
     
 
 def make(atm_mosaic_file: str, lnd_mosaic_file: str, ocn_mosaic_file: str,
-         topog_file: str, input_dir: str = "./"):    
+         topog_file: str, input_dir: str = "./", on_gpu: bool = False):    
     
     #read in mosaic files
     atm_mosaic = MosaicObj(input_dir=input_dir, mosaic_file=atm_mosaic_file).read()
@@ -208,7 +208,7 @@ def make(atm_mosaic_file: str, lnd_mosaic_file: str, ocn_mosaic_file: str,
     ocn_mask = get_ocn_mask(ocn_mosaic=ocn_mosaic, topog_file=topogfile_dict)
 
     #atmxocn
-    atmxocn = XGridObj(src_grid=atm_mosaic.grid, tgt_grid=extended_grid)
+    atmxocn = XGridObj(src_grid=atm_mosaic.grid, tgt_grid=extended_grid, on_gpu=on_gpu)
     atmxocn.create_xgrid(tgt_mask=ocn_mask)
 
     #undo extra ocn dimension
@@ -220,8 +220,8 @@ def make(atm_mosaic_file: str, lnd_mosaic_file: str, ocn_mosaic_file: str,
     for itile in ocn_mask: ocn_mask[itile] = np.float64(1.0) - ocn_mask[itile]
             
     #atmxocn the land part 
-    atmxocn_landpart = XGridObj(src_grid=atm_mosaic.grid, tgt_grid=extended_grid)
-    atmxocn_landpart.create_xgrid(tgt_mask=ocn_mask)    
+    atmxocn_landpart = XGridObj(src_grid=atm_mosaic.grid, tgt_grid=extended_grid, on_gpu=on_gpu)
+    atmxocn_landpart.create_xgrid(tgt_mask=ocn_mask)
     atmxlnd = get_atmxlnd(atmxocn_landpart, atm_mosaic=atm_mosaic)
             
     #write

--- a/tests/mosaic/test_coupler_mosaic.py
+++ b/tests/mosaic/test_coupler_mosaic.py
@@ -11,6 +11,13 @@ def test_make_coupler_mosaic():
                                      input_dir='/home/Mikyung.Lee/fmsgridtools/agridfix/tests/mosaic/input',
                                      topog_file='ocean_topog.nc')
 
+    fmsgridtools.coupler_mosaic.make(atm_mosaic_file='C48_mosaic.nc',
+                                     lnd_mosaic_file='C48_mosaic.nc',
+                                     ocn_mosaic_file='ocean_mosaic.nc',
+                                     input_dir='/home/Mikyung.Lee/fmsgridtools/agridfix/tests/mosaic/input',
+                                     topog_file='ocean_topog.nc',
+                                     on_gpu=True)
+
 
 if __name__ == "__main__":
     test_make_coupler_mosaic()

--- a/tests/mosaic/test_coupler_mosaic.py
+++ b/tests/mosaic/test_coupler_mosaic.py
@@ -11,6 +11,8 @@ def test_make_coupler_mosaic():
                                      input_dir='/home/Mikyung.Lee/fmsgridtools/agridfix/tests/mosaic/input',
                                      topog_file='ocean_topog.nc')
 
+    #number of cells differs by 2 for C48_mosaic_tile3Xocean_mosaic_tile1.nc
+    #might be due to precision error
     fmsgridtools.coupler_mosaic.make(atm_mosaic_file='C48_mosaic.nc',
                                      lnd_mosaic_file='C48_mosaic.nc',
                                      ocn_mosaic_file='ocean_mosaic.nc',


### PR DESCRIPTION
This PR adds `on_gpu` option to compute the coupler_mosaic.

Note, the test fails:  the number of exchange grid cells formed between C48 tile 3 and the ocn grid differs by 2 cells. 
This difference may be due to precision errors and will be checked in the future.